### PR TITLE
Fix missing shading and table border colors 

### DIFF
--- a/assets/styles/components/_colors.scss
+++ b/assets/styles/components/_colors.scss
@@ -1,10 +1,6 @@
 // Colors
 
-$color-1: (
-  epub: #373d3f,
-  prince: #373d3f,
-  web: #373d3f
-) !default; // Body & standard element text.
+$color-1: #373d3f !default; // Body & standard element text.
 $color-2: $color-1 !default; // Highlight for titles, some headings etc.
 $color-3: $color-1 !default; // Alternate highlight (defaults to $color-1).
 $color-4: #eee !default; // Shading.

--- a/assets/styles/components/_colors.scss
+++ b/assets/styles/components/_colors.scss
@@ -3,8 +3,8 @@
 $color-1: initial !default; // Body & standard element text.
 $color-2: initial !default; // Highlight for titles, some headings etc.
 $color-3: initial !default; // Alternate highlight (defaults to $color-1).
-$color-4: initial !default; // Shading.
-$color-5: initial !default; // Alternate shading.
+$color-4: #eee !default; // Shading.
+$color-5: $color-4 !default; // Alternate shading.
 
 //HTML ELEMENTS COLOR
 
@@ -26,7 +26,7 @@ $h6-color: $color-3 !default;
 $table-color: $color-1 !default;
 $table-para-color: $color-1 !default;
 $shade-color-1: $color-4 !default;
-$line-color-1: $color-3 !default; //FIX
+$line-color-1: black !default;
 
 //INDEX PARA COLOR
 

--- a/assets/styles/components/_colors.scss
+++ b/assets/styles/components/_colors.scss
@@ -1,10 +1,15 @@
 // Colors
 
-$color-1: initial !default; // Body & standard element text.
-$color-2: initial !default; // Highlight for titles, some headings etc.
-$color-3: initial !default; // Alternate highlight (defaults to $color-1).
+$color-1: (
+  epub: initial,
+  prince: initial,
+  web: #373d3f
+) !default; // Body & standard element text.
+$color-2: $color-1 !default; // Highlight for titles, some headings etc.
+$color-3: $color-1 !default; // Alternate highlight (defaults to $color-1).
 $color-4: #eee !default; // Shading.
 $color-5: $color-4 !default; // Alternate shading.
+$color-6: $color-1;
 
 //HTML ELEMENTS COLOR
 
@@ -26,7 +31,7 @@ $h6-color: $color-3 !default;
 $table-color: $color-1 !default;
 $table-para-color: $color-1 !default;
 $shade-color-1: $color-4 !default;
-$line-color-1: black !default;
+$line-color-1: $color-3 !default;
 
 //INDEX PARA COLOR
 

--- a/assets/styles/components/_colors.scss
+++ b/assets/styles/components/_colors.scss
@@ -1,8 +1,8 @@
 // Colors
 
 $color-1: (
-  epub: initial,
-  prince: initial,
+  epub: #373d3f,
+  prince: #373d3f,
   web: #373d3f
 ) !default; // Body & standard element text.
 $color-2: $color-1 !default; // Highlight for titles, some headings etc.

--- a/assets/styles/components/_elements.scss
+++ b/assets/styles/components/_elements.scss
@@ -61,10 +61,6 @@ $h3-border-bottom-width: $hx-border-bottom-width !default;
 $h3-border-bottom-color: $hx-border-bottom-color !default;
 
 // Heading 4
-
-
-
-
 $h4-margin-top: $hx-margin-top !default;
 $h4-margin-bottom: $hx-margin-bottom !default;
 $h4-padding-bottom: $hx-padding-bottom !default;
@@ -162,8 +158,6 @@ $blockquote-border-left-style: none !default;
 $blockquote-border-left-color: initial !default;
 
 // Lists
-
-
 $ol-margin-top: 1em !default;
 $ol-margin-bottom: 1em !default;
 $ol-margin-left: (epub: 2em, prince: 2em, web: 0) !default;


### PR DESCRIPTION
Declares color values for shading and line color. Also removes extra spacing from `_elements.scss` file (minor). Fixes: https://github.com/pressbooks/pressbooks-clarke/issues/49